### PR TITLE
Update MainFrame.java

### DIFF
--- a/src/main/java/me/friwi/jcefsampleapp/MainFrame.java
+++ b/src/main/java/me/friwi/jcefsampleapp/MainFrame.java
@@ -50,6 +50,7 @@ public class MainFrame extends JFrame {
     private MainFrame(String startURL, boolean useOSR, boolean isTransparent) throws UnsupportedPlatformException, CefInitializationException, IOException, InterruptedException {
         // (0) Initialize CEF using the maven loader
         CefAppBuilder builder = new CefAppBuilder();
+        // windowless_rendering_enabled must be set to false if not wanted. 
         builder.getCefSettings().windowless_rendering_enabled = useOSR;
         // USE builder.setAppHandler INSTEAD OF CefApp.addAppHandler!
         // Fixes compatibility issues with MacOSX


### PR DESCRIPTION
Just wanted to add a comment to warn programmers not remove the line of code without good reason. 

Without setting windowless_rendering_enabled=false the sample app browser would lock up with a spinning cursor (windows) or simply no response from clicks (linux). 

But I didn't want to label OSR as experimental or buggy-- (but it might be!?) Just not a clear setting and strange the default causes buggy behavior.